### PR TITLE
Resolve Command Fixture Depreciation Warnings

### DIFF
--- a/cowsay/tests/test_cowsay.py
+++ b/cowsay/tests/test_cowsay.py
@@ -10,8 +10,8 @@ def test_cowsay_installed(Package):
     assert p.is_installed
 
 
-def test_cowsay(Command):
-    cmd = Command('cowsay \'hello world!\'')
+def test_cowsay(host):
+    cmd = host.run('cowsay \'hello world!\'')
     expected = (' ______________\n'
                 '< hello world! >\n'
                 ' --------------\n'


### PR DESCRIPTION
While running the code, I was getting the following warning: 

```
    =============================== warnings summary ===============================
      Command fixture is deprecated. Use host fixture instead
      TestinfraBackend fixture is deprecated. Use host fixture and get backend with host.backend

    unknown file:0: RemovedInPytest4Warning: config.warn has been deprecated, use warnings.warn instead
    unknown file:0: RemovedInPytest4Warning: config.warn has been deprecated, use warnings.warn instead

    -- Docs: https://docs.pytest.org/en/latest/warnings.html
    ===================== 2 passed, 4 warnings in 2.48 seconds =====================
```

After making this change the depreciation warnings go away.

I'm using the following versions:
```
$ molecule --version
molecule, version 2.18.1
$ ansible --version
ansible 2.6.4
python version = 2.7.15
$ pip freeze | grep testinfra
testinfra==1.14.1
```